### PR TITLE
Configure Renovate for UDS-IdAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DUBBD_K3D_VERSION := 0.5.2
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
 ZARF_VERSION := v0.28.3
-# renovate: datasource=github-tags depName=defenseunicorns/uds-sso
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds-capability/uds-sso extractVersion=^(?<version>\d+\.\d+\.\d+)
 SSO_VERSION := 0.1.2
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/dubbd-k3d extractVersion=^(?<version>\d+\.\d+\.\d+)
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/dubbd-k3d extractVersion=^(?<version>\d+\.\d+\.\d+) 
 DUBBD_K3D_VERSION := 0.5.2
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
 ZARF_VERSION := v0.28.3

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+# renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/dubbd-k3d extractVersion=^(?<version>\d+\.\d+\.\d+)
 DUBBD_K3D_VERSION := 0.5.2
+# renovate: datasource=github-tags depName=defenseunicorns/zarf
 ZARF_VERSION := v0.28.3
+# renovate: datasource=github-tags depName=defenseunicorns/uds-sso
 SSO_VERSION := 0.1.2
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 

--- a/dev/test-mission-app/zarf.yaml
+++ b/dev/test-mission-app/zarf.yaml
@@ -13,7 +13,7 @@ components:
         kustomizations:
           - podinfo
     images:
-      - "ghcr.io/stefanprodan/podinfo:6.3.6"
+      - ghcr.io/stefanprodan/podinfo:6.3.6
     actions:
       onRemove:
         after:

--- a/idam/keycloak-flux-values.yaml
+++ b/idam/keycloak-flux-values.yaml
@@ -5,6 +5,7 @@ application:
   path: chart
   repository: https://repo1.dso.mil/big-bang/product/packages/keycloak.git
   ref:
+    # renovate: datasource=gitlab-tags depName=big-bang/product/packages/keycloak versioning=loose registryUrl=https://repo1.dso.mil
     tag: 18.4.3-bb.1
   values: |
     ###ZARF_VAR_KEYCLOAK_VALUES###

--- a/idam/zarf-config.yaml
+++ b/idam/zarf-config.yaml
@@ -1,8 +1,0 @@
-package:
-  create:
-    set:
-      repo: "https://repo1.dso.mil/big-bang/product/packages/keycloak"
-      tag: 18.4.3-bb.0
-      name: keycloak
-      namespace: keycloak
-      path: chart

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -87,7 +87,6 @@ components:
     required: true
     description: "Deploy keycloak via flux"
     charts:
-    charts:
     # renovate: datasource=helm
       - name: flux-app
         releaseName: keycloak-flux

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -89,12 +89,12 @@ components:
     charts:
     # renovate: datasource=helm
       - name: flux-app
-        releaseName: keycloak-flux
-        version: 1.0.5
         url: https://defenseunicorns.github.io/uds-support-charts/
+        version: 1.0.5
         namespace: bigbang
         valuesFiles:
           - keycloak-flux-values.yaml
+        releaseName: keycloak-flux
     repos:
       - https://repo1.dso.mil/big-bang/product/packages/keycloak.git
     images:
@@ -107,4 +107,3 @@ components:
           - cmd: ./zarf tools wait-for HelmRelease keycloak ready -n bigbang
             maxRetries: 3
             maxTotalSeconds: 300
-

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -91,10 +91,10 @@ components:
       - name: flux-app
         url: https://defenseunicorns.github.io/uds-support-charts/
         version: 1.0.5
+        releaseName: keycloak-flux
         namespace: bigbang
         valuesFiles:
           - keycloak-flux-values.yaml
-        releaseName: keycloak-flux
     repos:
       - https://repo1.dso.mil/big-bang/product/packages/keycloak.git
     images:

--- a/renovate.json
+++ b/renovate.json
@@ -76,12 +76,36 @@
     {
       "fileMatch": [".*\/?zarf\\.ya?ml$"],
       "matchStrings": [
-        "-\\s+['\"](?<depName>[^:]+):(?<currentValue>.*)['\"]"
+        "images:\\s*\\n((\\s+-\\s+.+\\n)+)",
+        "-\\s+(?<depName>[^:]+):(?<currentValue>.*)"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "matchStringsStrategy": "recursive",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
     },
+    {
+      "fileMatch": [".*\/?ingressgateway\\.ya?ml$"],
+      "matchStrings": [
+        "\\s+spec:\\s+hub:\\s+\\S+\\s+tag:\\s+(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "registry1.dso.mil/ironbank/tetrate/istio/proxyv2",
+      "matchStringsStrategy": "recursive",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },
+    {
+      "fileMatch": [".*\/?keycloak\\.ya?ml$"],
+      "matchStrings": [
+        "\\s+image:\\s+\\S+[^:]+:(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "registry1.dso.mil/ironbank/big-bang/p1-keycloak-plugin",
+      "matchStringsStrategy": "recursive",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },    
     {
       "fileMatch": ["^Makefile$"],
       "matchStrings": [
@@ -101,7 +125,7 @@
     {
       "matchPackagePatterns": ["big-bang/.*"],
       "matchDatasources": ["gitlab-tags"],
-      "allowedVersions": "!/^v.*$/"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-bb\\.(?<build>\\d+)$"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,107 @@
 {
+  "enabled": true,
+  "forkProcessing": "enabled",
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    "config:base",
+    "group:all",
+    "replacements:all",
+    "workarounds:all"
+  ],
+  "timezone": "America/New_York",
+  "rebaseStalePrs": true,
+  "schedule": ["after 7am and before 9am every weekday"],
+  "dependencyDashboard": true,
+  "platform": "github",
+  "onboarding": false,
+  "requireConfig": "optional",
+  "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "rebaseWhen": "conflicted",
+  "commitBodyTable": true,
+  "ignorePaths": ["archive/**"],
+  "suppressNotifications": ["prIgnoreNotification"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "helm-values": {
+    "fileMatch": ["./.+\\.yaml$"]
+  },
+  "kubernetes": {
+    "fileMatch": ["\\.yaml$"],
+    "ignorePaths": [
+      "ansible",
+      "scripts",
+      ".github"
+    ]
+  },
+  "hostRules": [
+    {
+      "matchHost": "registry1.dso.mil",
+      "hostType": "docker",
+      "description": "Encrypted creds for registry1, scoped to this Github org using: https://github.com/renovatebot/renovate/blob/main/docs/usage/configuration-options.md#encrypted",
+      "encrypted": {
+        "username": "wcFMA/xDdHCJBTolARAAiYqwOfwkjFnb7ifSRLxTGwyh5K8sUv4LFnEt9+clanU0hAoab9qY+98XLG9F5q+JuNWW9XSRgEYvg21LPhpux+2n+sF/n5UHNEc0X2C9zPVKBzRBu4RoNlsWNdq+wQaznHuw/iKmcDKddB29GTcXAC27ON78ex4jW4GBBEIY75OYfWUVJl3VM8cbK3t5iPNeldmdtS/1rEe8U2tGRdYvkwbMjM1hscHfc5wK06zt8NKz874jpqDYs9jT3FVrJbG9FHoTsrLvC9cEknu1BR3+LrEEV2UTpN+xkLbkCiI9F3rHwwYrAKpm3VDxjieWP2PbAZcazPvqNrC12pR3QrdbIN+6w7Xc9lIOuCcR+nB1mCTaZv4wGYoHmXat/nW58wAHqGzEnkfgfW7/dXvvZPoV/54CW2B8/iEp3oCf/mHk6tM/nlaN0fOcyFuLthD2t3L8bZEU8v88Bpa9sZgQYTg8vO3zGZeXqTznmq8NfseCXezho0syBize/4c7NI67JoVGJGUtOSZ56cNJkmNEhzH3CCKoD+j6shrojQ1yPLFgfxMa1zkp0tcAJ2dMxBbdMiGRKJcnJLRUi3N0z5I+JdydSZlFFj6Y+w7jWs1cff3mTyFCyhK3USyz+pF/ctTwpWixWWR7Zu/I0lqOr90LMri0bjzOf3xWP0eV3Osbi40BmdjScgG2LbZNVbKesnxaKLqzeubgLz9aTVTjHfHWQ753t4Ge/NPq+618M8JXuujYRc/Hw4bm1G7NHTKxPhiHCmDu+wPsNvt+nUvyk9Wb72XHYNdA8bUjV1gHj/1oSc3yGjOyiyaxDUR+nkPB8B+tr1cMWcVczw",
+        "password": "wcFMA/xDdHCJBTolAQ/9FqgG7wEhIpomA4DpTgDIQdShdkpUHxRCAaOXOaYamKxmyqQgX0N55hVvMt100/JK0AomtTehrWjsyYmvOA5bi2QqkJgEu7Vk/Nyg+CeJj27lZnbZ2wkWhIPUUZKbnGzNg8vmFqeSbI/nhcwwG+1Iiy06pBf/NB1V8KeezD3ICPJAe7HfW5FYDpuAnqo4ktagTEcmKp9bSztAEmNVgS325mE+SB5oGI7zZre4WLDmYCcawCJfwE2HqiWp9E42oiyEgsAa2RNmy/9RLMRq8QmAJY9UuAMDgyRUKh1bVEh2rhg3pV8N8ImqD8a7y/b5HOH5SE1b459K7rUACimJf8GtQtuUmU3bEhhYzafbN8sB6PByOgWEqPKvcCffLghCzsene4lOyie48rC0UZSTRrNiebcLLeJTnkQsUNm8x6GN34mZU4qkBam7Isvdyc7BcSo2rvMbsuMJEuns8Ua3TQlAab1PXofHjwf7aDPee4hLtJsR75IdeWA3mhPKo2hnZ08cBDwhsB7aXYxrH3rXAbPx7FvgcxGA73gCFwNXLf6S2xHb+D7C/ny4z9XhIQk4BrxKlmPFlfpELoijHQ34VBilM/XkeICbtBJghE31X3Ef/LZdLBsR9gvT4nK+zRRLVnEqndO4YkHFOjwKWQxyaGmN+ZE5gSbPx0R1EBo7vM48merSdgGRZxfF5OodxM/b3+xxBe6CXqi5yYVeNf/Op/lH/5baX6LUQCYHSNPXPHMstFYQm9QBwn6rA2aOYXojRehYwj8ymQo0wJ0TgVtGHDu+ODhTiPjZV1Mm7vVkucl63FLCDe7odIAgNVMBRInDbGYhKmA+I7To1gU"
+      }
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [".*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=helm\n .*- name: (?<depName>.*?)\n *url: (?<registryUrl>.*?)\n *version: (?<currentValue>.*)\n"
+      ],
+      "datasourceTemplate": "helm",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },
+    {
+      "fileMatch": [".*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?:\\s*['\"]?(?<currentValue>.*?)['\"]?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },
+    {
+      "fileMatch": [".*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: zarf-uri datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?uri: ['\"]https:\\/\\/github.com\\/defenseunicorns\\/zarf\\/releases\\/download\\/(?<currentValue>.*)\\/zarf_.*_Linux_amd64['\"]",
+        "# renovate: zarf-uri datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?uri: ['\"]https:\\/\\/github.com\\/defenseunicorns\\/zarf\\/releases\\/download\\/.*\\/zarf_(?<currentValue>.*)_Linux_amd64['\"]"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": [".*\/?zarf\\.ya?ml$"],
+      "matchStrings": [
+        "-\\s+['\"](?<depName>[^:]+):(?<currentValue>.*)['\"]"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    },
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?=\\s*['\"]?(?<currentValue>.*?)['\"]?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["terraform"],
+      "matchDepTypes": ["module"],
+      "matchDatasources": ["github-tags", "git-tags"],
+      "versioning": "loose"
+    },
+    {
+      "matchPackagePatterns": ["big-bang/.*"],
+      "matchDatasources": ["gitlab-tags"],
+      "allowedVersions": "!/^v.*$/"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
         "# renovate: zarf-uri datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?uri: ['\"]https:\\/\\/github.com\\/defenseunicorns\\/zarf\\/releases\\/download\\/(?<currentValue>.*)\\/zarf_.*_Linux_amd64['\"]",
         "# renovate: zarf-uri datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?uri: ['\"]https:\\/\\/github.com\\/defenseunicorns\\/zarf\\/releases\\/download\\/.*\\/zarf_(?<currentValue>.*)_Linux_amd64['\"]"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "datasourceTemplate": "github-tags"
     },
     {
@@ -80,7 +80,6 @@
         "-\\s+(?<depName>[^:]+):(?<currentValue>.*)"
       ],
       "matchStringsStrategy": "recursive",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
     },
@@ -91,7 +90,6 @@
       ],
       "depNameTemplate": "registry1.dso.mil/ironbank/tetrate/istio/proxyv2",
       "matchStringsStrategy": "recursive",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "datasourceTemplate": "docker",
       "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
     },


### PR DESCRIPTION
Covers all version referenced throughout repo. Accurately recommends the correct version updates. 

Additional Changes:
1. All image references are unquoted except for one, modified that reference to be unquoted as well for simplicity and also because it makes renovate regex easier.
2. /idam/zarf.yaml - flux-app fields needed to be reordered for regex to properly pick it up
3. /idam/zarf.yaml - also had a duplicate 'charts:' field defined, removed that
4. All other changes are renovate related, either in renovate regex comments or renovate.json


Tested on personal github fork.
