### PR TITLE
Adding a repo tag in the zarf package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/dubbd-k3d extractVersion=^(?<version>\d+\.\d+\.\d+)
-DUBBD_K3D_VERSION := 0.9.0
+DUBBD_K3D_VERSION := 0.11.0
 
 # renovate: datasource=github-tags depName=defenseunicorns/zarf
 ZARF_VERSION := v0.29.2
@@ -11,7 +11,7 @@ METALLB_VERSION := 0.0.1
 SSO_VERSION := 0.1.3
 
 # x-release-please-start-version
-IDAM_VERSION := 0.1.12
+IDAM_VERSION := 0.1.13
 # x-release-please-end
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -38,7 +38,7 @@ build/idam: | build
 	cd idam && zarf package create --tmpdir=/tmp --architecture amd64 --confirm --output ../build
 
 build/idam-postgres: | build
-	cd build && zarf package create ../pkg-deps/postgres --confirm 
+	cd build && zarf package create ../pkg-deps/postgres --confirm
 
 deploy/all: deploy/bundle
 
@@ -46,7 +46,7 @@ deploy/bundle:
 	cd dev && uds bundle deploy uds-bundle-uds-core-*.tar.zst --confirm
 
 test/idam: ## run all cypress tests
-	npm --prefix test/cypress/ install 
+	npm --prefix test/cypress/ install
 	npm --prefix test/cypress/ run cy.run
 
 pull/published: | build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ METALLB_VERSION := 0.0.1
 SSO_VERSION := 0.1.3
 
 # x-release-please-start-version
-IDAM_VERSION := 0.1.13
+IDAM_VERSION := 0.1.12
 # x-release-please-end
 
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/idam/keycloak-flux-values.yaml
+++ b/idam/keycloak-flux-values.yaml
@@ -6,7 +6,7 @@ application:
   repository: https://repo1.dso.mil/big-bang/product/packages/keycloak.git
   ref:
     # renovate: datasource=gitlab-tags depName=big-bang/product/packages/keycloak versioning=loose registryUrl=https://repo1.dso.mil
-    tag: 18.4.3-bb.2
+    tag: 18.4.3-bb.10
   values: |
     ###ZARF_VAR_KEYCLOAK_VALUES###
   dependsOn:

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -4,7 +4,7 @@ metadata:
   name: uds-idam
   description: "UDS Keycloak deployed via flux"
   # x-release-please-start-version
-  version: "0.1.13"
+  version: "0.1.12"
   # x-release-please-end
   architecture: amd64
 

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -110,6 +110,7 @@ components:
         valuesFiles:
           - keycloak-flux-values.yaml
     repos:
+      # renovate: datasource=gitlab-tags depName=big-bang/product/packages/keycloak versioning=loose registryUrl=https://repo1.dso.mil
       - https://repo1.dso.mil/big-bang/product/packages/keycloak.git@18.4.3-bb.10
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:21.1.1

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -4,9 +4,9 @@ metadata:
   name: uds-idam
   description: "UDS Keycloak deployed via flux"
   # x-release-please-start-version
-  version: "0.1.12"
+  version: "0.1.13"
   # x-release-please-end
-  architecture: amd64 
+  architecture: amd64
 
 variables:
   - name: REALM
@@ -14,7 +14,7 @@ variables:
     prompt: false
   - name: DOMAIN
     default: bigbang.dev
-    prompt: false  
+    prompt: false
   - name: KEYCLOAK_ADMIN_USERNAME
     default: admin
     prompt: false
@@ -110,7 +110,7 @@ components:
         valuesFiles:
           - keycloak-flux-values.yaml
     repos:
-      - https://repo1.dso.mil/big-bang/product/packages/keycloak.git
+      - https://repo1.dso.mil/big-bang/product/packages/keycloak.git@18.4.3-bb.10
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:21.1.1
       - registry1.dso.mil/ironbank/opensource/postgres/postgresql12:12.15


### PR DESCRIPTION
Adding a specific repo tag in the zarf package limits which branches are pulled into a package. This is helpful in avoiding force push conflicts in long-lived deployments (generally caused by renovate updates to unmerged feature branches).

Additionally, updated the DUBBD version to the most recent release to match the newly tagged version of the keycloak repo.