### PR TITLE
fix!: rename SUBDOMAIN to KEYCLOAK_SUBDOMAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make cluster/full
 | Name                      | Description                          | Default                                        | Type | Notes                  |
 |---------------------------|--------------------------------------|------------------------------------------------|------|------------------------|
 | REALM                     | Keycloak realm name                  | default-realm                                  |      |                        |
-| SUBDOMAIN                 | Subdomain for keycloak deployment    | keycloak                                       |      |                        |
+| KEYCLOAK_SUBDOMAIN                 | Subdomain for keycloak deployment    | keycloak                                       |      |                        |
 | DOMAIN                    | Base Domain                          | bigbang.dev                                    |      |                        |
 | KEYCLOAK_ADMIN_USERNAME   | Default admin username               | admin                                          |      |                        |
 | KEYCLOAK_ADMIN_PASSWORD   | Default admin password               | sup3r-secret-p@ssword                          |      |                        |

--- a/idam/keycloak-ingress/passthrough-gateway.yaml
+++ b/idam/keycloak-ingress/passthrough-gateway.yaml
@@ -8,7 +8,7 @@ spec:
     app: keycloak-ingressgateway
   servers:
   - hosts:
-    - '###ZARF_VAR_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
+    - '###ZARF_VAR_KEYCLOAK_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
     port:
       name: http
       number: 8080
@@ -16,7 +16,7 @@ spec:
     tls:
       httpsRedirect: true
   - hosts:
-    - '###ZARF_VAR_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
+    - '###ZARF_VAR_KEYCLOAK_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
     port:
       name: https
       number: 8443

--- a/idam/values-keycloak.yaml
+++ b/idam/values-keycloak.yaml
@@ -25,7 +25,7 @@ extraEnv: |-
   - name: KC_HTTP_RELATIVE_PATH
     value: /auth
   - name: KC_HOSTNAME
-    value: ###ZARF_VAR_SUBDOMAIN###.###ZARF_VAR_DOMAIN###
+    value: ###ZARF_VAR_KEYCLOAK_SUBDOMAIN###.###ZARF_VAR_DOMAIN###
   - name: KC_HOSTNAME_STRICT
     value: "true"
   - name: KC_HOSTNAME_STRICT_HTTPS
@@ -122,7 +122,7 @@ istio:
     gateways:
     - istio-system/passthrough
     hosts:
-    - '###ZARF_VAR_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
+    - '###ZARF_VAR_KEYCLOAK_SUBDOMAIN###.###ZARF_VAR_DOMAIN###'
 
 monitoring:
   enabled: false

--- a/idam/zarf.yaml
+++ b/idam/zarf.yaml
@@ -12,7 +12,7 @@ variables:
   - name: REALM
     default: baby-yoda
     prompt: false
-  - name: SUBDOMAIN
+  - name: KEYCLOAK_SUBDOMAIN
     default: keycloak
     prompt: false
   - name: DOMAIN


### PR DESCRIPTION
BREAKING CHANGE: Scope subdomain zarf variable for uds-idam 